### PR TITLE
Add listening post access to sleepers

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -514,6 +514,8 @@ TYPEINFO(/obj/machinery/door/airlock/pyro/reinforced)
 	req_access_txt = "52"
 	cyborgBumpAccess = FALSE
 
+/obj/machinery/door/airlock/pyro/reinforced/syndicate/listening_post
+
 /obj/machinery/door/airlock/pyro/reinforced/arrivals
 	icon_state = "arrivals_closed"
 	icon_base = "arrivals"

--- a/code/obj/machinery/sleeperscanner.dm
+++ b/code/obj/machinery/sleeperscanner.dm
@@ -1,0 +1,25 @@
+/obj/machinery/sleeperscanner
+	name = "Hand Scanner"
+	icon = 'icons/obj/decoration.dmi'
+	icon_state = "handscanner"
+	desc = "A device embedded into the wall, it has a image of a handprint on it."
+
+/obj/machinery/sleeperscanner/attackby(obj/item/W, mob/user as mob)
+	if(istype(W, /obj/item/device/detective_scanner))
+		return
+	if (user.mind?.get_antagonist(ROLE_SLEEPER_AGENT) && user.mind?.get_antagonist(ROLE_SLEEPER_AGENT))
+		user.visible_message("<span class='notice'>The [src] accepts the biometrics of the user and beeps, granting you access.</span>")
+		for (var/obj/machinery/door/airlock/pyro/reinforced/syndicate/listening_post/M in by_type[/obj/machinery/door])
+			M.open()
+	else
+		boutput(user, "<span class='alert'>Invalid biometric profile. Access denied.</span>")
+
+/obj/machinery/sleeperscanner/attack_hand(mob/user)
+	src.add_fingerprint(user)
+	playsound(src.loc, 'sound/effects/handscan.ogg', 50, 1)
+	if (ishuman(user) && user.mind?.get_antagonist(ROLE_SLEEPER_AGENT))
+		user.visible_message("<span class='notice'>The [src] accepts the biometrics of the user and beeps, granting you access.</span>")
+		for (var/obj/machinery/door/airlock/pyro/reinforced/syndicate/listening_post/M in by_type[/obj/machinery/door])
+			M.open()
+	else
+		boutput(user, "<span class='alert'>Invalid biometric profile. Access denied.</span>")

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1924,6 +1924,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\obj\machinery\shower.dm"
 #include "code\obj\machinery\singularity.dm"
 #include "code\obj\machinery\sleeper.dm"
+#include "code\obj\machinery\sleeperscanner.dm"
 #include "code\obj\machinery\spaceheater.dm"
 #include "code\obj\machinery\status_display.dm"
 #include "code\obj\machinery\traymachines.dm"

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -12061,7 +12061,9 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "aMR" = (
-/obj/machinery/door/airlock/pyro/reinforced/syndicate,
+/obj/machinery/door/airlock/pyro/reinforced/syndicate/listening_post{
+	name = "Listening Post"
+	},
 /turf/simulated/floor/red,
 /area/listeningpost)
 "aMS" = (
@@ -12204,6 +12206,9 @@
 	dir = 1;
 	layer = 9.1;
 	pixel_y = 21
+	},
+/obj/machinery/sleeperscanner{
+	pixel_y = 24
 	},
 /turf/simulated/floor/redblack{
 	dir = 1
@@ -12633,6 +12638,9 @@
 /obj/item/tank/oxygen,
 /obj/machinery/light{
 	layer = 3
+	},
+/obj/machinery/sleeperscanner{
+	pixel_y = -35
 	},
 /turf/simulated/floor/redblack,
 /area/listeningpost)
@@ -17565,6 +17573,12 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/heads)
+"jik" = (
+/obj/machinery/sleeperscanner{
+	pixel_y = 37
+	},
+/turf/space,
+/area/space)
 "jiT" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -19300,6 +19314,12 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
+"tDV" = (
+/obj/machinery/sleeperscanner{
+	pixel_y = -35
+	},
+/turf/space,
+/area/space)
 "tEj" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -19687,7 +19707,7 @@
 /area/station/hallway/primary/north)
 "wlm" = (
 /obj/displaycase{
-	displayed = new /obj/item/captaingun()
+	displayed = new/obj/item/captaingun()
 	},
 /turf/simulated/floor/blue,
 /area/station/bridge/captain)
@@ -95796,7 +95816,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+tDV
 agK
 aMX
 aNf
@@ -95812,7 +95832,7 @@ aOO
 aNf
 aMX
 aYB
-aaa
+jik
 aaa
 aaa
 aaa

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -18092,11 +18092,11 @@
 /turf/simulated/floor/plating,
 /area/listeningpost/power)
 "bKG" = (
-/obj/machinery/door/airlock/syndicate{
-	desc = "Seems to be a pretty sturdy door.";
+/obj/decal/stripe_delivery,
+/obj/machinery/door/airlock/pyro/reinforced/syndicate/listening_post{
+	dir = 4;
 	name = "Listening Post"
 	},
-/obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/listeningpost)
 "bKH" = (
@@ -32113,7 +32113,7 @@
 	},
 /obj/table/wood/auto,
 /obj/displaycase{
-	displayed = new /obj/item/captaingun();
+	displayed = new/obj/item/captaingun();
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet/arcade,
@@ -40620,6 +40620,14 @@
 	dir = 1
 	},
 /area/station/quartermaster/office)
+"tZf" = (
+/obj/machinery/sleeperscanner{
+	pixel_x = 22
+	},
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/listeningpost)
 "tZF" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -43272,6 +43280,12 @@
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
+"wgZ" = (
+/obj/machinery/sleeperscanner{
+	pixel_y = -25
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "wie" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -44713,6 +44727,14 @@
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/bridge)
+"xAg" = (
+/obj/machinery/sleeperscanner{
+	pixel_y = 24
+	},
+/turf/simulated/floor/stairs{
+	dir = 8
+	},
+/area/listeningpost)
 "xAx" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -102497,7 +102519,7 @@ aab
 bCl
 bFQ
 bFQ
-bFQ
+wgZ
 bKK
 bLb
 bLj
@@ -103010,7 +103032,7 @@ bJY
 bJY
 bJY
 bJY
-bKH
+xAg
 bKK
 bKK
 bLd
@@ -103783,7 +103805,7 @@ lXD
 iiM
 mAw
 bKP
-bKX
+tZf
 mIt
 bLn
 bKX

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -3477,6 +3477,12 @@
 /area/station/hangar/catering{
 	name = "Catering Hangar"
 	})
+"amp" = (
+/obj/machinery/sleeperscanner{
+	pixel_x = 20
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "amq" = (
 /obj/securearea{
 	pixel_y = -4
@@ -40769,12 +40775,11 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
 "czG" = (
-/obj/machinery/door/airlock/pyro/reinforced/syndicate{
-	desc = "Seems to be a pretty sturdy door.";
+/obj/decal/stripe_delivery,
+/obj/machinery/door/airlock/pyro/reinforced/syndicate/listening_post{
 	dir = 4;
 	name = "Listening Post"
 	},
-/obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/listeningpost)
 "czH" = (
@@ -42336,6 +42341,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
+"dfz" = (
+/obj/machinery/sleeperscanner{
+	pixel_y = 24
+	},
+/turf/simulated/floor/stairs{
+	dir = 8
+	},
+/area/listeningpost)
 "dfG" = (
 /obj/landmark/start/job/cyborg,
 /turf/simulated/floor/black,
@@ -50973,6 +50986,14 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/staff)
+"kSl" = (
+/obj/machinery/sleeperscanner{
+	pixel_x = 20
+	},
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/listeningpost)
 "kTI" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -144722,7 +144743,7 @@ aap
 czz
 czz
 czN
-czV
+amp
 sAI
 cAj
 cAr
@@ -145324,7 +145345,7 @@ sAI
 sAI
 sAI
 sAI
-czH
+dfz
 sAI
 czW
 sAI
@@ -146232,7 +146253,7 @@ czt
 czB
 czJ
 czP
-czP
+kSl
 cAd
 cAm
 cAv

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -62439,11 +62439,11 @@
 /turf/simulated/floor/plating,
 /area/listeningpost/power)
 "dnw" = (
-/obj/machinery/door/airlock/pyro/reinforced/syndicate{
+/obj/decal/stripe_delivery,
+/obj/machinery/door/airlock/pyro/reinforced/syndicate/listening_post{
 	dir = 4;
 	name = "Listening Post"
 	},
-/obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/listeningpost)
 "dnx" = (
@@ -72119,6 +72119,12 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/icing,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/kitchen)
+"ruM" = (
+/obj/machinery/sleeperscanner{
+	pixel_y = -25
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "rvg" = (
 /obj/table/reinforced/auto,
 /obj/mapping_helper/firedoor_spawn,
@@ -75092,6 +75098,14 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"wkW" = (
+/obj/machinery/sleeperscanner{
+	pixel_x = 22
+	},
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/listeningpost)
 "wld" = (
 /obj/machinery/door/airlock/pyro/reinforced/arrivals,
 /obj/decal/stripe_delivery,
@@ -75246,6 +75260,14 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/mining/magnet)
+"wFI" = (
+/obj/machinery/sleeperscanner{
+	pixel_y = 24
+	},
+/turf/simulated/floor/stairs{
+	dir = 8
+	},
+/area/listeningpost)
 "wGP" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/black,
@@ -155430,7 +155452,7 @@ aab
 aaF
 aan
 aan
-aan
+ruM
 dnA
 dnR
 dnZ
@@ -156033,7 +156055,7 @@ dmJ
 dmJ
 dmJ
 dmJ
-dnx
+wFI
 dnA
 dnA
 dnT
@@ -156941,7 +156963,7 @@ dnh
 dnr
 dnz
 dnF
-dnN
+wkW
 dnW
 dod
 dnN

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -352,6 +352,9 @@
 	},
 /area/space)
 "abg" = (
+/obj/machinery/sleeperscanner{
+	pixel_x = 20
+	},
 /turf/simulated/floor/plating/airless{
 	dir = 10;
 	icon_state = "ast1"
@@ -30139,12 +30142,11 @@
 /turf/simulated/floor/plating,
 /area/station/turret_protected/Zeta)
 "hSA" = (
-/obj/machinery/door/airlock/pyro/reinforced/syndicate{
-	desc = "Seems to be a pretty sturdy door.";
+/obj/decal/stripe_delivery,
+/obj/machinery/door/airlock/pyro/reinforced/syndicate/listening_post{
 	dir = 4;
 	name = "Listening Post"
 	},
-/obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/listeningpost)
 "hSU" = (
@@ -32248,6 +32250,14 @@
 	dir = 5
 	},
 /area/station/science/teleporter)
+"jwW" = (
+/obj/machinery/sleeperscanner{
+	pixel_x = 20
+	},
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/listeningpost)
 "jxd" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -37484,7 +37494,7 @@
 	pixel_y = 6
 	},
 /obj/displaycase{
-	displayed = new /obj/item/captaingun()
+	displayed = new/obj/item/captaingun()
 	},
 /obj/blind_switch/area/west{
 	pixel_y = -6
@@ -46700,6 +46710,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/ce)
+"tPb" = (
+/obj/machinery/sleeperscanner{
+	pixel_y = 24
+	},
+/turf/simulated/floor/stairs{
+	dir = 8
+	},
+/area/listeningpost)
 "tPe" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -70763,7 +70781,7 @@ vrb
 vrb
 vrb
 vrb
-aaS
+tPb
 vrb
 abh
 vrb
@@ -71671,7 +71689,7 @@ aaE
 aaM
 aaU
 aba
-aba
+jwW
 abo
 abv
 abE

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -5962,6 +5962,9 @@
 "bHz" = (
 /obj/stool/chair/red,
 /obj/machinery/bot/medbot/no_camera,
+/obj/machinery/sleeperscanner{
+	pixel_y = 24
+	},
 /turf/simulated/floor/grey/side,
 /area/listeningpost)
 "bHA" = (
@@ -16655,7 +16658,10 @@
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/sec_foyer)
 "eZz" = (
-/obj/machinery/door/airlock/pyro/external,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Listening Post";
+	dir = 4
+	},
 /obj/mapping_helper/access/maint,
 /obj/decal/mule/dropoff,
 /obj/disposalpipe/segment{
@@ -18527,7 +18533,10 @@
 /area/station/bridge/customs)
 "fEk" = (
 /obj/decal/cleanable/dirt/jen,
-/obj/machinery/door/airlock/pyro/external,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Listening Post";
+	dir = 4
+	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "fEp" = (
@@ -30213,7 +30222,10 @@
 /turf/simulated/floor/plating,
 /area/station/quartermaster/refinery)
 "jjJ" = (
-/obj/machinery/door/airlock/pyro/external,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Listening Post";
+	dir = 4
+	},
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
 "jjO" = (
@@ -32744,7 +32756,10 @@
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/podbay)
 "jVR" = (
-/obj/machinery/door/airlock/pyro/external,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Listening Post";
+	dir = 4
+	},
 /obj/mapping_helper/access/research,
 /obj/mapping_helper/firedoor_spawn,
 /obj/decal/mule/dropoff,
@@ -33112,7 +33127,10 @@
 	},
 /area/station/security/quarters)
 "kbY" = (
-/obj/machinery/door/airlock/pyro/external,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Listening Post";
+	dir = 4
+	},
 /obj/mapping_helper/access/maint,
 /obj/decal/mule/dropoff,
 /obj/forcefield/energyshield/perma/doorlink{
@@ -33236,7 +33254,10 @@
 	name = "Genetic Research"
 	})
 "kff" = (
-/obj/machinery/door/airlock/pyro/external,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Listening Post";
+	dir = 4
+	},
 /obj/mapping_helper/access/maint,
 /obj/decal/mule/dropoff,
 /turf/simulated/floor/plating/jen,
@@ -33843,7 +33864,10 @@
 /turf/simulated/floor/plating,
 /area/station/security/beepsky)
 "kpd" = (
-/obj/machinery/door/airlock/pyro/external,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Listening Post";
+	dir = 4
+	},
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/inner/north)
 "kpf" = (
@@ -34748,7 +34772,10 @@
 	},
 /area/station/hallway/primary/south)
 "kDF" = (
-/obj/machinery/door/airlock/pyro/external,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Listening Post";
+	dir = 4
+	},
 /obj/mapping_helper/access/research,
 /obj/decal/mule/dropoff,
 /turf/simulated/floor/plating,
@@ -39753,7 +39780,6 @@
 "mcd" = (
 /obj/machinery/door/airlock/pyro,
 /obj/decal/mule/dropoff,
-/obj/mapping_helper/access/syndie_shuttle,
 /turf/simulated/floor/sanitary,
 /area/listeningpost)
 "mcE" = (
@@ -42919,6 +42945,12 @@
 "nea" = (
 /turf/simulated/floor/carpet/blue/standard,
 /area/station/medical/medbay/cloner)
+"nes" = (
+/obj/machinery/sleeperscanner{
+	pixel_x = 20
+	},
+/turf/simulated/floor/airless/plating/jen,
+/area/space)
 "neE" = (
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /obj/machinery/vending/standard,
@@ -45571,7 +45603,10 @@
 /area/station/engine/elect)
 "nTs" = (
 /obj/decal/mule/dropoff,
-/obj/machinery/door/airlock/pyro/external,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Listening Post";
+	dir = 4
+	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/maint,
 /turf/simulated/floor/sanitary/blue,
@@ -46320,7 +46355,10 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig/south_side)
 "ohP" = (
-/obj/machinery/door/airlock/pyro/external,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Listening Post";
+	dir = 4
+	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/decal/mule/dropoff,
 /obj/mapping_helper/access/heads,
@@ -47939,7 +47977,10 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/west)
 "oHo" = (
-/obj/machinery/door/airlock/pyro/external,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Listening Post";
+	dir = 4
+	},
 /obj/mapping_helper/access/maint,
 /obj/decal/mule/dropoff,
 /obj/forcefield/energyshield/perma/doorlink{
@@ -49149,7 +49190,10 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "pas" = (
-/obj/machinery/door/airlock/pyro/external,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Listening Post";
+	dir = 4
+	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/medical,
 /obj/mapping_helper/access/maint,
@@ -49826,7 +49870,10 @@
 /area/station/crew_quarters/kitchen)
 "pkQ" = (
 /obj/decal/mule/dropoff,
-/obj/machinery/door/airlock/pyro/external,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Listening Post";
+	dir = 4
+	},
 /obj/mapping_helper/access,
 /obj/mapping_helper/firedoor_spawn,
 /obj/decal/tile_edge/line/white{
@@ -55446,7 +55493,10 @@
 /turf/simulated/floor/orangeblack,
 /area/station/hallway/secondary/exit)
 "qTv" = (
-/obj/machinery/door/airlock/pyro/external,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Listening Post";
+	dir = 4
+	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/medical,
 /obj/forcefield/energyshield/perma/doorlink{
@@ -57323,7 +57373,10 @@
 /turf/simulated/floor/pool/no_animate,
 /area/spacehabitat/pool)
 "rxf" = (
-/obj/machinery/door/airlock/pyro/external,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Listening Post";
+	dir = 4
+	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/medical,
 /obj/mapping_helper/access/maint,
@@ -59634,6 +59687,9 @@
 	dir = 4;
 	status = 2
 	},
+/obj/machinery/sleeperscanner{
+	pixel_x = -31
+	},
 /turf/simulated/floor/plating/jen,
 /area/listeningpost)
 "siO" = (
@@ -60230,11 +60286,11 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "ssN" = (
-/obj/machinery/door/airlock/pyro/reinforced/syndicate{
-	name = "Listening Post"
-	},
 /obj/decal/mule/dropoff,
-/obj/mapping_helper/access/syndie_shuttle,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Listening Post";
+	dir = 4
+	},
 /turf/simulated/floor/carpet/grime,
 /area/listeningpost)
 "ssO" = (
@@ -74461,15 +74517,14 @@
 	},
 /area/station/science/lobby)
 "wLC" = (
-/obj/machinery/door/airlock/pyro/reinforced/syndicate{
-	dir = 4;
-	name = "Listening Post"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/decal/mule/dropoff,
-/obj/mapping_helper/access/syndie_shuttle,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Listening Post";
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/listeningpost)
 "wLK" = (
@@ -79446,7 +79501,10 @@
 /turf/simulated/floor/plating/jen,
 /area/station/science/gen_storage)
 "yfa" = (
-/obj/machinery/door/airlock/pyro/external,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Listening Post";
+	dir = 4
+	},
 /obj/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -160230,7 +160288,7 @@ csA
 csA
 csA
 csA
-xzQ
+nes
 eML
 iOW
 iOW

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -60288,8 +60288,7 @@
 "ssN" = (
 /obj/decal/mule/dropoff,
 /obj/machinery/door/airlock/pyro/external{
-	name = "Listening Post";
-	dir = 4
+	name = "Listening Post"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/listeningpost)

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -30909,14 +30909,17 @@
 /turf/simulated/floor/plating,
 /area/station/chapel/sanctuary)
 "cms" = (
+/obj/machinery/sleeperscanner{
+	pixel_y = 24
+	},
 /turf/simulated/floor/plating/airless/asteroid/dark,
 /area/listeningpost)
 "cmt" = (
-/obj/machinery/door/airlock/syndicate{
-	desc = "Seems to be a pretty sturdy door.";
-	name = "Listening Post"
-	},
 /obj/decal/stripe_delivery,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Listening Post";
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/listeningpost)
 "cmu" = (
@@ -30929,6 +30932,10 @@
 	layer = 2.5;
 	name = "VACUUM AREA";
 	pixel_y = -32
+	},
+/obj/machinery/sleeperscanner{
+	pixel_y = -26;
+	pixel_x = 18
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
@@ -52920,6 +52927,14 @@
 "sNP" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/dome)
+"sOs" = (
+/obj/machinery/sleeperscanner{
+	pixel_x = -20
+	},
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/listeningpost)
 "sOE" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/storage{
@@ -141574,7 +141589,7 @@ ckU
 clL
 clT
 cme
-cme
+sOs
 cmw
 cmF
 cmJ

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -5391,7 +5391,6 @@
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Medical Bay"
 	},
-/obj/mapping_helper/access/syndie_shuttle,
 /turf/simulated/floor/shuttle{
 	icon_state = "floor3"
 	},
@@ -10618,7 +10617,6 @@
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Power Systems"
 	},
-/obj/mapping_helper/access/syndie_shuttle,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -16735,7 +16733,6 @@
 /area/station/bridge/captain)
 "hpO" = (
 /obj/machinery/door/airlock/pyro/reinforced/syndicate,
-/obj/mapping_helper/access/syndie_shuttle,
 /turf/simulated/floor/black,
 /area/listeningpost)
 "hqD" = (
@@ -41093,6 +41090,9 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/sleeperscanner{
+	pixel_y = 24
+	},
 /turf/simulated/floor/redblack,
 /area/listeningpost)
 "rSs" = (
@@ -42554,7 +42554,6 @@
 /obj/machinery/door/airlock/pyro{
 	name = "Personnel"
 	},
-/obj/mapping_helper/access/syndie_shuttle,
 /turf/simulated/floor/black,
 /area/listeningpost)
 "sxE" = (
@@ -42975,7 +42974,6 @@
 /obj/machinery/door/airlock/pyro{
 	name = "Restroom"
 	},
-/obj/mapping_helper/access/syndie_shuttle,
 /turf/simulated/floor/blackwhite{
 	dir = 1
 	},
@@ -43399,6 +43397,12 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"sPM" = (
+/obj/machinery/sleeperscanner{
+	pixel_y = 24
+	},
+/turf/space/fluid/acid,
+/area/space)
 "sPN" = (
 /obj/surgery_tray,
 /obj/item/clothing/gloves/latex,
@@ -48747,6 +48751,9 @@
 /obj/item/nanoloom_cartridge{
 	pixel_x = -7;
 	pixel_y = -4
+	},
+/obj/machinery/sleeperscanner{
+	pixel_x = 20
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
@@ -54097,11 +54104,10 @@
 	name = "Nuclear Control Room"
 	})
 "xHG" = (
-/obj/machinery/door/airlock/pyro/reinforced/syndicate{
-	desc = "Seems to be a pretty sturdy door.";
-	name = "Exploratory Capsule"
-	},
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/machinery/door/airlock/pyro/reinforced/syndicate/listening_post{
+	name = "Listening Post"
+	},
 /turf/simulated/floor/black,
 /area/listeningpost)
 "xHM" = (
@@ -87173,7 +87179,7 @@ vkb
 qQg
 fhm
 gYn
-bzS
+sPM
 bzS
 bzS
 bzS

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -13417,6 +13417,10 @@
 /obj/stool/chair{
 	dir = 1
 	},
+/obj/machinery/sleeperscanner{
+	pixel_y = -26;
+	pixel_x = 18
+	},
 /turf/simulated/floor/black,
 /area/listeningpost)
 "aQs" = (
@@ -14020,8 +14024,7 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/info)
 "aSj" = (
-/obj/machinery/door/airlock/pyro/reinforced/syndicate{
-	desc = "Seems to be a pretty sturdy door.";
+/obj/machinery/door/airlock/pyro/reinforced/syndicate/listening_post{
 	name = "Listening Post"
 	},
 /turf/simulated/floor/black,
@@ -14044,6 +14047,9 @@
 /turf/simulated/floor/stairs/wide/middle,
 /area/listeningpost)
 "aSn" = (
+/obj/machinery/sleeperscanner{
+	pixel_x = 20
+	},
 /turf/simulated/floor/stairs/wide/other,
 /area/listeningpost)
 "aSo" = (
@@ -14076,8 +14082,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "aSs" = (
-/obj/machinery/door/airlock/pyro/reinforced/syndicate{
-	desc = "Seems to be a pretty sturdy door.";
+/obj/machinery/door/airlock/pyro/reinforced/syndicate/listening_post{
 	name = "Listening Post"
 	},
 /turf/simulated/floor,
@@ -44156,6 +44161,12 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/security/main)
+"sJH" = (
+/obj/machinery/sleeperscanner{
+	pixel_y = 24
+	},
+/turf/space/fluid,
+/area/space)
 "sJY" = (
 /mob/living/carbon/human/npc/monkey,
 /obj/machinery/light/incandescent/warm,
@@ -55584,7 +55595,7 @@ aPm
 aPm
 aPm
 aPm
-aqn
+sJH
 aqn
 aqn
 aqn

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -890,6 +890,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/chapel/sanctuary)
+"ark" = (
+/obj/machinery/light/emergency{
+	dir = 4
+	},
+/obj/machinery/sleeperscanner{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "arw" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -16540,6 +16549,12 @@
 /obj/item/pen/fancy,
 /turf/simulated/floor/wood,
 /area/station/chapel/sanctuary)
+"hcD" = (
+/obj/machinery/sleeperscanner{
+	pixel_x = -20
+	},
+/turf/simulated/floor/black,
+/area/listeningpost)
 "hcE" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
@@ -26153,14 +26168,13 @@
 	},
 /area/station/catwalk/south)
 "leD" = (
-/obj/machinery/door/airlock/pyro/reinforced/syndicate{
-	desc = "Seems to be a pretty sturdy door.";
-	name = "Listening Post"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/mapping_helper/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/reinforced/syndicate/listening_post{
+	name = "Listening Post"
+	},
 /turf/simulated/floor/black,
 /area/listeningpost)
 "leO" = (
@@ -37554,6 +37568,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/sleeperscanner{
+	pixel_x = 20
+	},
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -45146,8 +45163,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "tkj" = (
-/obj/machinery/door/airlock/pyro/reinforced/syndicate{
-	desc = "Seems to be a pretty sturdy door.";
+/obj/machinery/door/airlock/pyro/reinforced/syndicate/listening_post{
 	dir = 4;
 	name = "Listening Post"
 	},
@@ -62058,7 +62074,7 @@ xxT
 lyx
 mWu
 xxT
-tEt
+ark
 tpS
 rQD
 tEt
@@ -62962,7 +62978,7 @@ gGo
 jgF
 xxT
 lTU
-nnW
+hcD
 xxT
 pVt
 rdH


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This is a rework of  #15222 which is a rework of #14992 because I messed something up again. This PR adds handscanners to the listening post which allow sleeper agents to leave and enter it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This gives sleepers access to items in the listening post giving them traitor items without the full power of the traitor uplink. This makes them feel like more then a late HMT.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Cheekybrdy
(*)Sleeper agents can now access the listening post through scanners at the entrance.
```
