### PR TITLE
Adds the missing clown holo module to Nadir

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -1274,6 +1274,10 @@
 /obj/item/instrument/bikehorn,
 /obj/item/stamp/clown,
 /obj/item/reagent_containers/food/snacks/pie/cream,
+/obj/item/aiModule/hologram_expansion/clown{
+	pixel_x = 4;
+	pixel_y = 10
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/clown{
 	name = "Honkington's Abode"
@@ -19360,6 +19364,11 @@
 	dir = 4
 	},
 /area/station/security/main)
+"iqn" = (
+/turf/space,
+/area/station/hallway/secondary/construction{
+	name = "The Warrens"
+	})
 "iqo" = (
 /obj/machinery/light{
 	dir = 8;
@@ -108166,7 +108175,7 @@ qlx
 pRb
 pRb
 pRb
-vbY
+iqn
 oZL
 bSU
 kcY


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a clown hologram module to nadir, which is currently missing.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Standardised map items good.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->
